### PR TITLE
Prefix any function that returns JSX with _render

### DIFF
--- a/01-react-components.md
+++ b/01-react-components.md
@@ -5,3 +5,4 @@
 * Use propTypes
 * Avoid the use of state, prefer props
 * Prefix any function not part of React life cycle methods with an underscore ```_``` character
+* Prefix any function that returns JSX with ```_render```


### PR DESCRIPTION
We do this in several places already. I think it cleans up react components in general in terms of readability.